### PR TITLE
Allow specifying a set of extensions to process

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,18 @@
 var through = require('through2');
+var path = require('path');
 var jstransform = require('jstransform').transform;
 
 var reJSONFile = /\.json$/;
 
 var visitorList = require('./unreachableBranchVisitors').visitorList;
 
-function process(file/*, opts*/) {
+function process(file, opts) {
+  // pass exts to whitelist a set of extensions to process.
+  var exts = [].concat(opts.exts || [])
+
   if (reJSONFile.test(file)) return through();
+  if (exts.length && exts.indexOf(path.extname(file)) === -1) return through();
+
   var buf = '';
   return through(function(chunk, enc, cb) {
     buf += chunk;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,12 @@ var visitorList = require('./unreachableBranchVisitors').visitorList;
 
 function process(file, opts) {
   // pass exts to whitelist a set of extensions to process.
-  var exts = [].concat(opts.exts || [])
+  var exts = [].concat(opts.exts || []).map(function(ext) {
+      // Make sure all extensions start with a . because path.extname(file)
+      // includes the .
+      if (ext.charAt(0) === '.') return ext
+      return '.' + ext
+  })
 
   if (reJSONFile.test(file)) return through();
   if (exts.length && exts.indexOf(path.extname(file)) === -1) return through();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreachable-branch-transform",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Browserify transform (and jstransform visitor) to comment out unreachable code branches",
   "keywords": [
     "browserify",


### PR DESCRIPTION
I have a project where I'm using [lessbuildify](https://github.com/deepsweet/lessbuildify) and I need to make sure `unreachable-branch-transform` skips the `.less` files.

```
browserify     \
  -t lessbuildifyy \
  -t [ unreachable-branch-transform -exts .js -exts .coffee ]
```
