### PR TITLE
optional options

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var recast = require('recast');
 var transformer = require('./unreachableBranchTransformer');
 
 module.exports = function (file, opts) {
+  opts = opts || [];
   var ignore = ['.json'].concat(opts.ignore || []).some(function(ext) {
     return file.indexOf(ext, file.length - ext.length) !== -1;
   });


### PR DESCRIPTION
fixes an issue I had with `unreachable-branch-transform` with [this branch](https://github.com/ethereum/ethereum.js/tree/unreach2.1) of my project

``` bash
/Users/marekkotewicz/ethereum/ethereum.js/node_modules/unreachable-branch-transform/index.js:7
  var ignore = ['.json'].concat(opts.ignore || []).some(function(ext) {
                                    ^
TypeError: Cannot read property 'ignore' of undefined
    at module.exports (/Users/marekkotewicz/ethereum/ethereum.js/node_modules/unreachable-branch-transform/index.js:7:37)
    at nr (/Users/marekkotewicz/ethereum/ethereum.js/node_modules/browserify/node_modules/module-deps/index.js:281:23)
    at /Users/marekkotewicz/ethereum/ethereum.js/node_modules/browserify/node_modules/resolve/lib/async.js:44:21
    at ondir (/Users/marekkotewicz/ethereum/ethereum.js/node_modules/browserify/node_modules/resolve/lib/async.js:187:31)
    at /Users/marekkotewicz/ethereum/ethereum.js/node_modules/browserify/node_modules/resolve/lib/async.js:153:39
    at onex (/Users/marekkotewicz/ethereum/ethereum.js/node_modules/browserify/node_modules/resolve/lib/async.js:93:22)


    at /Users/marekkotewicz/ethereum/ethereum.js/node_modules/browserify/node_modules/resolve/lib/async.js:24:18
    at Object.oncomplete (fs.js:107:15)
```
